### PR TITLE
update ingreso.php and usuariosModels.php

### DIFF
--- a/models/ingreso.php
+++ b/models/ingreso.php
@@ -14,8 +14,6 @@ class IngresoModels{
 
 		return $stmt -> fetch();
 
-		$stmt -> close();
-
 	}
 
 	public static function intentosModel($datosModel, $tabla){

--- a/models/usuariosModels.php
+++ b/models/usuariosModels.php
@@ -16,9 +16,6 @@ public static function vistaUsuariosModel($tabla){
 
 		return $stmt -> fetchAll();
 
-		$stmt -> close();
-
-
 }
 
 
@@ -48,8 +45,6 @@ public static function registroUsuariosModel($datosModel, $tabla){
 			return "error";
 
 		}
-
-		$stmt->close();
 
 	}
 
@@ -82,8 +77,6 @@ public static function registroUsuariosModel($datosModel, $tabla){
 
 		}
 
-		$stmt->close();
-
 	}
 
 
@@ -107,8 +100,6 @@ public static function registroUsuariosModel($datosModel, $tabla){
 			return "error";
 
 		}
-
-		$stmt->close();
 
 	}
 


### PR DESCRIPTION
No existe la función 'close' en PDO de php en cambio PDO cuando sale del alcance se libera automáticamente aunque también se puede forzar definiendo lo como 'null'.
Aparte de lo mencionado al llamar a 'return' en una función sale del alcance por lo tanto nunca se llama a '$stmt -> close();'.

Igualmente si se prueba poniendo '$stmt->close();' antes del 'return' este da una excepción.

> Fatal error: Uncaught Error: Call to undefined method PDOStatement::close()
